### PR TITLE
include StateProvinceCode for all destinations

### DIFF
--- a/Nop.Plugin.Shipping.Fedex/Services/FedexService.cs
+++ b/Nop.Plugin.Shipping.Fedex/Services/FedexService.cs
@@ -466,8 +466,7 @@ public class FedexService
 
         var recipientCountryCode = (await _countryService.GetCountryByAddressAsync(getShippingOptionRequest.ShippingAddress))?.TwoLetterIsoCode ?? string.Empty;
 
-        if (await _stateProvinceService.GetStateProvinceByAddressAsync(getShippingOptionRequest.ShippingAddress) is { } stateProvince &&
-            IncludeStateProvinceCode(recipientCountryCode))
+        if (await _stateProvinceService.GetStateProvinceByAddressAsync(getShippingOptionRequest.ShippingAddress) is { } stateProvince)
             request.RequestedShipment.Recipient.Address.StateOrProvinceCode = stateProvince.Abbreviation;
         else
             request.RequestedShipment.Recipient.Address.StateOrProvinceCode = string.Empty;


### PR DESCRIPTION
although state/province is only REQUIRED on US,CA,MX and PR shipments. leaving it empty can often result in failed rate requests or invalid rate quotes, or frequent error logs `Shipping (FedEx). The destination state/province code has been changed.`

it is best to include it when you can, especially since it will not make the request any less valid.

This resolved most US international shipping errors.