### PR TITLE
improve error logging to show more details from fedex api

### DIFF
--- a/Nop.Plugin.Shipping.Fedex/Services/FedexService.cs
+++ b/Nop.Plugin.Shipping.Fedex/Services/FedexService.cs
@@ -882,6 +882,13 @@ public class FedexService
 
             return response;
         }
+        catch (API.Rates.ApiException<API.Rates.ErrorResponseVO> e)
+        {
+            Debug.WriteLine(e.Message);
+            response.AddError(e.Message);
+            response.AddError(string.Join(Environment.NewLine, e.Result.Errors.Select(error => $"{error.Code}: {error.Message}")));
+            return response;
+        }
         catch (Exception e)
         {
             Debug.WriteLine(e.Message);


### PR DESCRIPTION
add another catch to resolve more specific API error details.
this could probably be extended to all APIException<T> types, but 400 bad request (using `API.Rates.ApiException<API.Rates.ErrorResponseVO>`) seems to be the most common.

Shows store operator real error information about what was wrong with the request instead of generic "400 bad request (who knows what happened)".

possibly resolves #17 - could likely use some polishing