### PR TITLE
make DelayDetails a List

### DIFF
--- a/Nop.Plugin.Shipping.Fedex/API/Rates/RateClient.cs
+++ b/Nop.Plugin.Shipping.Fedex/API/Rates/RateClient.cs
@@ -2072,7 +2072,7 @@ namespace Nop.Plugin.Shipping.Fedex.API.Rates
         public DateDetail DateDetail { get; set; }
 
         [Newtonsoft.Json.JsonProperty("delayDetails", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public DelayDetail DelayDetails { get; set; }
+        public IList<DelayDetail> DelayDetails { get; set; }
 
         /// <summary>
         /// Specifies the saturdayDelivery.


### PR DESCRIPTION
I was occassionally getting `Could not deserialize the response body string as Nop.Plugin.Shipping.Fedex.API.Rates.RatcResponseVO.` error.

when i rewrote some code to get more verbose logging i found:
```log
--> Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'Nop.Plugin.Shipping.Fedex.API.Rates.DelayDetail' because the type requires a JSON object (e.g. {"name":"value"}) to deserialize correctly.
To fix this error either change the JSON to a JSON object (e.g. {"name":"value"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.
Path 'output.rateReplyDetails[0].commit.delayDetails', line 1, position 396.
```

Raw FedEx Json shows an array:
<img width="381" height="197" alt="Screenshot 2026-04-15 144817" src="https://github.com/user-attachments/assets/decf7dd4-b727-42e5-8ded-ccebde379da8" />

FedEx docs show "object":
<img width="766" height="507" alt="Screenshot 2026-04-15 144849" src="https://github.com/user-attachments/assets/0eb61aa9-78b9-49ec-aad2-0c5cb38c1341" />

since it looks like FedEx could serve the DelayDetails data as either a single object or an array and DelayDetails aren't actually used anywhere else in the code, it could probably just be removed from deserialization without side effect.

As a side note, i have it running with ILIst<DelayDetails> right now and it is not causing any side effects, so the docs may just be wrong.